### PR TITLE
[Classifiers] [Setup Metadata] Adding Classifiers block and including…

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [year] [fullname]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,11 @@ setup(
     license='MIT',
     url='https://github.com/emissions-api/sentinel5dl',
     packages=find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],    
     install_requires=open('requirements.txt').read().splitlines(),
     long_description=open('readme.md').read(),
     entry_points={


### PR DESCRIPTION
#### About
* Adding classifiers block to `setup.py`
* Introducing the `LICENCSE.md` file.

#### Testing
```
➜  sentinel5dl git:(master-classifiers) ✗ python3 setup.py develop            
running develop
running egg_info
writing sentinel5dl.egg-info/PKG-INFO
writing dependency_links to sentinel5dl.egg-info/dependency_links.txt
writing entry points to sentinel5dl.egg-info/entry_points.txt
writing requirements to sentinel5dl.egg-info/requires.txt
writing top-level names to sentinel5dl.egg-info/top_level.txt
reading manifest file 'sentinel5dl.egg-info/SOURCES.txt'
writing manifest file 'sentinel5dl.egg-info/SOURCES.txt'
running build_ext
Creating /home/linuxbrew/.linuxbrew/lib/python3.7/site-packages/sentinel5dl.egg-link (link to .)
Adding sentinel5dl 0.1 to easy-install.pth file
Installing sentinel5dl script to /home/linuxbrew/.linuxbrew/bin

Installed /home/pseudoaj/github-workspace/sentinel5dl
Processing dependencies for sentinel5dl==0.1
Searching for pycurl==7.43.0.3
Best match: pycurl 7.43.0.3
Processing pycurl-7.43.0.3-py3.7-linux-x86_64.egg
pycurl 7.43.0.3 is already the active version in easy-install.pth

Using /home/linuxbrew/.linuxbrew/lib/python3.7/site-packages/pycurl-7.43.0.3-py3.7-linux-x86_64.egg
Finished processing dependencies for sentinel5dl==0.1
```

This fixes #2 