### PR TITLE
Store MD5 Checksums

### DIFF
--- a/sentinel5dl/__init__.py
+++ b/sentinel5dl/__init__.py
@@ -38,6 +38,28 @@ def __md5(filename):
     return hash_md5.hexdigest().upper()
 
 
+def __check_md5(filename, base_path):
+    '''Check the md5 sum of a given file against the ESA API.
+
+    :param filename: Path of local file to check
+    :param base_path: Base API path to for this product
+    :returns: If the local file matches the md5 checksum
+    :rtype: bool
+    '''
+    md5file = f'{filename}.md5sum'
+    try:
+        with open(md5file, 'r') as f:
+            md5sum = f.read()
+    except FileNotFoundError:
+        md5sum = __http_request(f'{base_path}/Checksum/Value/$value')
+        md5sum = md5sum.decode('ascii')
+        with open(md5file, 'w') as f:
+            f.write(md5sum)
+
+    # Compare md5 sum
+    return __md5(filename) == md5sum
+
+
 def __http_request(path, filename=None):
     '''Make an HTTP request to the API via HTTP, optionally downloading the
     response.
@@ -140,20 +162,15 @@ def download(products, output_dir='.'):
         uuid = product['uuid']
         filename = os.path.join(output_dir, product['identifier'] + '.nc')
         logger.info(f'Downloading {uuid} to {filename}')
-        path = f'/odata/v1/Products(\'{uuid}\')/$value'
+        base_path = f"/odata/v1/Products('{uuid}')"
 
         # Check if file exist
         if os.path.exists(filename):
-            # Get md5 sum
-            md5um_path = f"/odata/v1/Products('{uuid}')/Checksum/Value/$value"
-            md5sum = __http_request(md5um_path)
-            md5sum = md5sum.decode()
-
-            # Compare md5 sum
-            if __md5(filename) == md5sum:
+            # Skip download if checksum matches
+            if __check_md5(filename, base_path):
                 logger.info(f'Skipping {filename} since it already exist.')
                 continue
             logger.info(f'Overriding {filename} since md5 hash differs.')
 
         # Download file
-        __http_request(path, filename)
+        __http_request(f'{base_path}/$value', filename)

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -12,18 +12,22 @@ class TestSentinel5dl(unittest.TestCase):
     def _mock_http_request(self, path, filename=None):
         '''Mock HTTP requests to the ESA API
         '''
+        # download
         if filename is not None:
             self._count_download += 1
             with open(filename, 'wb') as f:
                 f.write(b'123')
             return
 
-        # no nownload
-        self._count_request += 1
+        # search request
         if path.startswith('/api/stub/products?'):
+            self._count_search_request += 1
             with open(os.path.join(testpath, 'products.json'), 'rb') as f:
                 return f.read()
+
+        # checksum request
         if path.endswith('/Checksum/Value/$value'):
+            self._count_checksum_request += 1
             # MD5 checksum for string `123`
             return b'202CB962AC59075B964B07152D234B70'
 
@@ -32,7 +36,8 @@ class TestSentinel5dl(unittest.TestCase):
         make any HTTP requests and reset the request counters.
         '''
         setattr(sentinel5dl, '__http_request', self._mock_http_request)
-        self._count_request = 0
+        self._count_search_request = 0
+        self._count_checksum_request = 0
         self._count_download = 0
 
     def test(self):
@@ -46,7 +51,7 @@ class TestSentinel5dl(unittest.TestCase):
 
         # The result returned by the mock contains four products but claims a
         # total of eight products, making sentinel5dl request resources twice.
-        self.assertEqual(self._count_request, 2)
+        self.assertEqual(self._count_search_request, 2)
         self.assertEqual(result['totalresults'], 8)
         self.assertEqual(result['totalresults'], len(result['products']))
 
@@ -66,10 +71,12 @@ class TestSentinel5dl(unittest.TestCase):
                 with open(filename, 'rb') as f:
                     self.assertEqual(f.read(), b'123')
 
-        # We should have made an additional five requests for checksums:
-        # - one for the file we created manually
-        # - four for the duplicated entries in the loaded test data
-        self.assertEqual(self._count_request, 7)
+            # We should have downloaded four files and have an additional four
+            # files storing md5 checksums
+            self.assertEqual(len(os.listdir(tmpdir)), 8)
+
+        # We should have four checksum requests. One for each file
+        self.assertEqual(self._count_checksum_request, 4)
         # We should have downloaded four unique files
         self.assertEqual(self._count_download, 4)
 


### PR DESCRIPTION
This patch stores the MD5 checksums next to the downloaded filenames so
that they do not need to be requested via HTTP every time. This makes
repeatedly skipping existing files a lot faster.

This fixes #23