### PR TITLE
Add Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@ dist: bionic
 
 # https://devguide.python.org/#branchstatus
 python:
-  - "3.6"
-  - "3.7"
+  - 3.6
+  - 3.7
+  - 3.8
 
 addons:
   apt:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Operating System :: OS Independent',
         'Topic :: Scientific/Engineering :: GIS',
     ],


### PR DESCRIPTION
This patch adds support for Python 3.8 by adding it to the PyPI
classifiers and enabling 3.8 in the Travis CI build matrix.