### PR TITLE
Fix Documentation

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?=
+SPHINXOPTS    ?= -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,4 +1,4 @@
-.. include:: ../../readme.rst
+.. include:: ../../README.rst
 
 
 .. toctree::


### PR DESCRIPTION
This patch fixes the documentation which was trying to include a
non-existing file. With this patch, such problems will now be treated as
errors.