### PR TITLE
Coveralls Documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,12 @@ addons:
       - libgnutls28-dev
 
 install:
-  - pip install flake8 coverage
-  - pip install coveralls
+  - pip install flake8 coverage coveralls
   - python setup.py install
 
 script:
   - flake8 sentinel5dl
   - coverage run --source=sentinel5dl -m tests
-  - coverage report
 
 after_success:
   - pip install sphinx sphinx-rtd-theme

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,10 @@ Sentinel-5P Downloader
 
 .. image:: https://travis-ci.com/emissions-api/sentinel5dl.svg?branch=master
     :target: https://travis-ci.com/emissions-api/sentinel5dl
+    :alt: CI Builds
+.. image:: https://coveralls.io/repos/github/emissions-api/sentinel5dl/badge.svg?branch=master
+    :target: https://coveralls.io/github/emissions-api/sentinel5dl?branch=master
+    :alt: Test Coverage
 .. image:: https://img.shields.io/github/issues-raw/emissions-api/sentinel5dl?color=blue
     :target: https://github.com/emissions-api/sentinel5dl/issues
     :alt: GitHub issues


### PR DESCRIPTION
This patch adds the Coveralls badge to the main readme file and removes
the temporary coverage listing from the Travis CI builds.

Related to #18