### PR TITLE
Mock pycURL for Documentation Builds

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath('../../'))
-import sentinel5dl
 
 
 # -- Project information -----------------------------------------------------
@@ -53,3 +52,5 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 #html_static_path = ['_static']
+
+autodoc_mock_imports = ["pycurl"]


### PR DESCRIPTION
This patch mocks pycURL during the Sphinx documentation builds. This
should not change the resulting documentation but is required for
building them on readthedocs.io since it does not support installing
C-libraries.