### PR TITLE
Use kebab-case for cmd options

### DIFF
--- a/sentinel5dl/__main__.py
+++ b/sentinel5dl/__main__.py
@@ -126,7 +126,7 @@ def main():
     )
 
     parser.add_argument(
-        '--begin_ts',
+        '--begin-ts',
         default='2019-09-01T00:00:00.000Z',
         type=validate_date_string,
         help='''ISO-8601 timestamp specifying the earliest sensing date.
@@ -134,7 +134,7 @@ def main():
     )
 
     parser.add_argument(
-        '--end_ts',
+        '--end-ts',
         default='2019-09-17T23:59:59.999Z',
         type=validate_date_string,
         help='''ISO-8601 timestamp specifying the latest sensing date.


### PR DESCRIPTION
This patch switches to using kebab-case for command line options since
this is way more common.