### PR TITLE
Time Specification

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pycurl>=7.43.0
-iso8601==0.1.12
+python-dateutil==2.8.1
 certifi==2019.11.28

--- a/sentinel5dl/__init__.py
+++ b/sentinel5dl/__init__.py
@@ -6,7 +6,6 @@
 '''Sentinel-5P Downloader
 '''
 
-import datetime
 import hashlib
 import io
 import json
@@ -151,10 +150,15 @@ def search(polygon=None, begin_ts=None, end_ts=None, product=None,
     :param per_request_limit: Limit number of results per request
     :returns: Dictionary containing information about found products
     '''
-    if type(begin_ts) == datetime.datetime:
+    try:
         begin_ts = begin_ts.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
-    if type(end_ts) == datetime.datetime:
+    except AttributeError:
+        pass
+    try:
         end_ts = end_ts.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    except AttributeError:
+        pass
+
     count = 0
     total = 1
     data = None

--- a/sentinel5dl/__init__.py
+++ b/sentinel5dl/__init__.py
@@ -6,6 +6,7 @@
 '''Sentinel-5P Downloader
 '''
 
+import datetime
 import hashlib
 import io
 import json
@@ -143,14 +144,17 @@ def search(polygon=None, begin_ts=None, end_ts=None, product=None,
     '''Search for products via API.
 
     :param polygon: WKT polygon specifying an area the data should intersect
-    :param begin_ts: ISO-8601 timestamp specifying the earliest sensing date
-    :param end_ts: ISO-8601 timestamp specifying the latest sensing date
+    :param begin_ts: Datetime specifying the earliest sensing date
+    :param end_ts: Datetime specifying the latest sensing date
     :param product: Type of product to request
     :param processing_level: Data processing level (`L1B` or `L2`)
     :param per_request_limit: Limit number of results per request
     :returns: Dictionary containing information about found products
     '''
-
+    if type(begin_ts) == datetime.datetime:
+        begin_ts = begin_ts.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+    if type(end_ts) == datetime.datetime:
+        end_ts = end_ts.strftime('%Y-%m-%dT%H:%M:%S.%fZ')
     count = 0
     total = 1
     data = None

--- a/sentinel5dl/__main__.py
+++ b/sentinel5dl/__main__.py
@@ -9,7 +9,7 @@ Sentinel-5p Downloader
 '''
 
 import argparse
-import iso8601
+import dateutil.parser
 import certifi
 import logging
 import textwrap
@@ -77,19 +77,6 @@ def is_polygon(polygon):
     return f'POLYGON(({polygon}))'
 
 
-def validate_date_string(date_string):
-    '''Validate that the supplied argument is a valid iso8601 date-time string.
-
-    :param date_string: Date string to validate
-    :return: Supplied date string
-    '''
-    try:
-        iso8601.parse_date(date_string)
-    except iso8601.iso8601.ParseError:
-        raise ValueError('Unable to parse date')
-    return date_string
-
-
 def main():
     # Configure logging in the library
     logging.basicConfig()
@@ -129,16 +116,16 @@ def main():
     parser.add_argument(
         '--begin-ts',
         default='2019-09-01T00:00:00.000Z',
-        type=validate_date_string,
-        help='''ISO-8601 timestamp specifying the earliest sensing date.
+        type=dateutil.parser.parse,
+        help='''Timestamp specifying the earliest sensing date.
             Example: 2019-09-01T00:00:00.000Z'''
     )
 
     parser.add_argument(
         '--end-ts',
         default='2019-09-17T23:59:59.999Z',
-        type=validate_date_string,
-        help='''ISO-8601 timestamp specifying the latest sensing date.
+        type=dateutil.parser.parse,
+        help='''Timestamp specifying the latest sensing date.
             Example: 2019-09-17T23:59:59.999Z'''
     )
 

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import sentinel5dl
 import tempfile
@@ -45,8 +46,8 @@ class TestSentinel5dl(unittest.TestCase):
         '''
         result = sentinel5dl.search(
             polygon='POLYGON((7 49,13 49,13 52,7 52,7 49))',
-            begin_ts='2019-09-01T00:00:00.000Z',
-            end_ts='2019-09-17T23:59:59.999Z',
+            begin_ts=datetime.datetime.fromtimestamp(0),
+            end_ts=datetime.datetime.now(),
             product='L2__CO____')
 
         # The result returned by the mock contains four products but claims a


### PR DESCRIPTION
The Copernicus API is very picky when it comes to date/time formats,
accepting only a subset of ISO-8601 time strings. To make working with
the API easier and less error-prone, this patch makes sentinel5dl accept
datetime objects for time specification, automatically converting them
into the required string representation.