### PR TITLE
Requirement Version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pycurl>=7.43.0
-python-dateutil==2.8.1
-certifi==2019.11.28
+pycurl
+python-dateutil
+certifi


### PR DESCRIPTION
This patch removes the explicit versioning for dependencies to avoid
conflicts when using this library.