### PR TITLE
Return Result on Retry

### DIFF
--- a/sentinel5dl/__init__.py
+++ b/sentinel5dl/__init__.py
@@ -122,7 +122,7 @@ def __http_request(path, filename=None, retries=9):
             raise err
         logger.warning('Retrying failed HTTP request. %s', err)
         time.sleep(1)
-        __http_request(path, filename, retries-1)
+        return __http_request(path, filename, retries-1)
 
 
 def _search(polygon, begin_ts, end_ts, product, processing_level,


### PR DESCRIPTION
This patch fixes a bug where the result of non-file HTTP requests would
not be properly returned but just be discarded with no warnings on
retries.