### PR TITLE
Fix Renaming Temporary Files

### DIFF
--- a/sentinel5dl/__init__.py
+++ b/sentinel5dl/__init__.py
@@ -109,10 +109,11 @@ def __http_request(path, filename=None, retries=9):
             curl.perform()
             curl.close()
 
-            if filename:
-                os.rename(f'{filename}.tmp', filename)
-            else:
+            if not filename:
                 return f.getvalue()
+
+        # rename temporary file if we downloaded one
+        os.rename(f'{filename}.tmp', filename)
 
     except pycurl.error as err:
         if not retries:


### PR DESCRIPTION
This patch fixes the renaming of temporary files on Windows which fails
with the error that a process still has an open file handler on these
files. The process is sentinal5dl itself which did not close the file
yet.

This fixes #70
This fixes #71