### PR TITLE
Linting via GitHub Actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+name: lint
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.10'
+
+    - name: install Python dependencies
+      run: pip install bandit flake8
+
+    - name: run flake8
+      run: flake8 sentinel5dl tests
+
+    - name: run bandit
+      run: bandit -r sentinel5dl tests


### PR DESCRIPTION
This patch adds a GitHub Actions workflow to run flake8 and bandit on the sentinel5dl source code.