### PR TITLE
Fix Response Format

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -14,7 +14,7 @@ testpath = os.path.dirname(os.path.abspath(__file__))
 
 class TestSentinel5dl(unittest.TestCase):
 
-    def _mock_http_request(self, path, filename=None):
+    def _mock_http_request(self, path, filename=None, headers=[]):
         '''Mock HTTP requests to the ESA API
         '''
         # download


### PR DESCRIPTION
In some cases, sentinel5dl would fail with an error when searching for products:

    json.decoder.JSONDecodeError: Expecting value: ...

This patch fixes the issue by specifically telling the Sentinel API to return JSON and not XML data as a response to our search request.