### PR TITLE
Fix Build Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Sentinel-5P Downloader
 ======================
 
-.. image:: https://travis-ci.com/emissions-api/sentinel5dl.svg?branch=master
-    :target: https://travis-ci.com/emissions-api/sentinel5dl
+.. image:: https://app.travis-ci.com/emissions-api/sentinel5dl.svg?branch=main
+    :target: https://app.travis-ci.com/emissions-api/sentinel5dl
     :alt: CI Builds
 .. image:: https://coveralls.io/repos/github/emissions-api/sentinel5dl/badge.svg?branch=master
     :target: https://coveralls.io/github/emissions-api/sentinel5dl?branch=master


### PR DESCRIPTION
This patch updates the Travis CI build bade which still pointed to an old Travis URL and to the branch `master` instead of the current default branch `main`.